### PR TITLE
Add functionality for multiple robots

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # This gitignore has been specially created by the WPILib team.
 # If you remove items from this file, intellisense might break.
 
+#302 build details file
+src/main/utilities/BuildDetails.txt
+
 ### C++ ###
 # Prerequisites
 *.d

--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 # If you remove items from this file, intellisense might break.
 
 #302 build details file
-src/main/utilities/BuildDetails.txt
+../src/main/utilities/BuildDetails.txt
 
 ### C++ ###
 # Prerequisites

--- a/.wpilib/wpilib_preferences.json
+++ b/.wpilib/wpilib_preferences.json
@@ -2,5 +2,5 @@
     "enableCppIntellisense": true,
     "currentLanguage": "cpp",
     "projectYear": "2023",
-    "teamNumber": 302
+    "teamNumber": 2
 }

--- a/.wpilib/wpilib_preferences.json
+++ b/.wpilib/wpilib_preferences.json
@@ -2,5 +2,5 @@
     "enableCppIntellisense": true,
     "currentLanguage": "cpp",
     "projectYear": "2023",
-    "teamNumber": 303
+    "teamNumber": 302
 }

--- a/.wpilib/wpilib_preferences.json
+++ b/.wpilib/wpilib_preferences.json
@@ -2,5 +2,5 @@
     "enableCppIntellisense": true,
     "currentLanguage": "cpp",
     "projectYear": "2023",
-    "teamNumber": 302
+    "teamNumber": 303
 }

--- a/build.gradle
+++ b/build.gradle
@@ -66,7 +66,7 @@ tasks.build.doLast() {
    def branch = stdout.toString().trim()
 
    new File(projectDir.toString() + "/src/main/utilities", "BuildDetails.txt"
-   ).text = "Branch: (B)" + branch + "(B) "+ "\nCommit Hash: (H)" + commitHash + "(H)" + "\nTeam Number: (TN)" + project.frc.getTeamNumber() + "(TN)"
+   ).text = "Branch: (B)" + branch + "(B) "+ "\nCommit Hash: (H)" + commitHash + "(H)" + "\nTeam Number: (TN)" + project.frc.getTeamOrDefault(302) + "(TN)"
 
     println("Wrote details")
     if(ant.properties.answer == 'N' || ant.properties.answer == 'n')
@@ -87,7 +87,7 @@ model {
             String lastBuildDetails = new File(projectDir.toString() + "/src/main/utilities/BuildDetails.txt").text
 
             String lastTeamNum = lastBuildDetails.takeBetween("(TN)")
-            if(lastTeamNum.toInteger() != project.frc.getTeamNumber())
+            if(lastTeamNum.toInteger() != project.frc.getTeamOrDefault(302))
             {
                 
                 ant.input(message: 'Current team number does not match what code was built with, continue? Y/N:', addproperty: 'answer', defaultValue : 'N')
@@ -101,7 +101,7 @@ model {
 
             sources.cpp {
                 def cppDir = 'src/main/cpp/' //default will be comp bot, will make src/main/cpp/comp later
-                switch(project.frc.getTeamNumber()){
+                switch(project.frc.getTeamOrDefault(302)){
                     case 302:
                         println("Building code for comp bot")
                         //don't need to set cppDir because it already points to comp bot

--- a/build.gradle
+++ b/build.gradle
@@ -56,19 +56,20 @@ def greenColor = "32"
 def yellowColor = "33"
 def ansiEnd = "m"
 def endSequence = ansiEscape + resetText + ansiEnd
+def boldSequence = ansiEscape + boldEffect + ansiEnd
 
 /// Check current team number and the team number used to build
 /// If theres a mismatch, allow the user to either continue or stop the build
 tasks.discoverroborio.doFirst() {
-    println("Checking team numbers")
+    println("Checking team numbers...")
     //check for version mismatch
     String lastBuildDetails = new File(projectDir.toString() + "/src/main/utilities/BuildDetails.txt").text
 
     String lastTeamNum = lastBuildDetails.takeBetween("(TN)")
     if(lastTeamNum.toInteger() != project.frc.getTeamOrDefault(302))
     {
-        println("Last built with team number: " + lastTeamNum)
-        println("Current team number: " + project.frc.getTeamOrDefault(302))
+        println(boldSequence + "> Last built with team number: " + endSequence + lastTeamNum)
+        println(boldSequence + "> Current team number: " + endSequence + project.frc.getTeamOrDefault(302))
         def startSequence = ansiEscape + boldEffect + ";" + yellowColor + ansiEnd
         ant.input(message: startSequence + 'WARNING: ' + endSequence + 'Current team number does not match what code was built with, continue? Y/N:', addproperty: 'answer', defaultValue : 'N')
         def answer = ant.properties.answer
@@ -108,7 +109,6 @@ tasks.build.doLast() {
     def secondSequence = ansiEscape + brightGreenColor + ansiEnd
     println(startSequence + "Wrote build details to: " + endSequence + path + "/" + filename)
 
-    def boldSequence = ansiEscape + boldEffect + ansiEnd
     def branchString = "\n\t" + boldSequence + "Branch: " + endSequence + branch
     def commitString = "\n\t" + boldSequence + "Commit Hash: " + endSequence + commitHash
     def teamNumString = "\n\t" + boldSequence + "Team Number: " + secondSequence + project.frc.getTeamOrDefault(302) + endSequence
@@ -127,7 +127,6 @@ model {
             sources.cpp {
                 def cppDir = 'src/main/cpp/' //default will be comp bot, will make src/main/cpp/comp later
                 
-                def boldSequence = ansiEscape + boldEffect + ansiEnd
                 switch(project.frc.getTeamOrDefault(302)){
                     case 302:
                         print(boldSequence)

--- a/build.gradle
+++ b/build.gradle
@@ -46,9 +46,42 @@ wpi.sim.addGui().defaultEnabled = true
 // Enable DS but not by default
 wpi.sim.addDriverstation()
 
+/// Variables for coloring/formatting terminal output, uses ANSI codes
+def ansiEscape = "\033["
+def boldEffect = "1"
+def resetText = "0"
+def redColor = "31"
+def brightGreenColor = "92"
+def greenColor = "32"
+def yellowColor = "33"
+def ansiEnd = "m"
+def endSequence = ansiEscape + resetText + ansiEnd
+
+/// Check current team number and the team number used to build
+/// If theres a mismatch, allow the user to either continue or stop the build
+tasks.discoverroborio.doFirst() {
+    println("Checking team numbers")
+    //check for version mismatch
+    String lastBuildDetails = new File(projectDir.toString() + "/src/main/utilities/BuildDetails.txt").text
+
+    String lastTeamNum = lastBuildDetails.takeBetween("(TN)")
+    if(lastTeamNum.toInteger() != project.frc.getTeamOrDefault(302))
+    {
+        println("Last built with team number: " + lastTeamNum)
+        println("Current team number: " + project.frc.getTeamOrDefault(302))
+        def startSequence = ansiEscape + boldEffect + ";" + yellowColor + ansiEnd
+        ant.input(message: startSequence + 'WARNING: ' + endSequence + 'Current team number does not match what code was built with, continue? Y/N:', addproperty: 'answer', defaultValue : 'N')
+        def answer = ant.properties.answer
+        if(answer == 'N' || answer == 'n')
+        {
+            startSequence = ansiEscape + boldEffect + ";" + redColor + ansiEnd
+            throw new GradleException(startSequence + "Deploy stopped due to team number mismatch" + endSequence)
+        }
+    }
+}
+
 tasks.build.doLast() {
    def stdout = new ByteArrayOutputStream()
-
    exec {
      commandLine "git", "rev-parse", "HEAD"
      standardOutput = stdout
@@ -65,14 +98,22 @@ tasks.build.doLast() {
    // Parse the output into a string
    def branch = stdout.toString().trim()
 
-   new File(projectDir.toString() + "/src/main/utilities", "BuildDetails.txt"
+   def path = "/src/main/utilities"
+   def filename = "BuildDetails.txt"
+
+   new File(projectDir.toString() + path, filename
    ).text = "Branch: (B)" + branch + "(B) "+ "\nCommit Hash: (H)" + commitHash + "(H)" + "\nTeam Number: (TN)" + project.frc.getTeamOrDefault(302) + "(TN)"
 
-    println("Wrote details")
-    if(ant.properties.answer == 'N' || ant.properties.answer == 'n')
-    {
-        println("Build was not successful even though it says that below.  Please rebuild")
-    }
+    def startSequence = ansiEscape + boldEffect + ";" + brightGreenColor + ansiEnd
+    def secondSequence = ansiEscape + brightGreenColor + ansiEnd
+    println(startSequence + "Wrote build details to: " + endSequence + path + "/" + filename)
+
+    def boldSequence = ansiEscape + boldEffect + ansiEnd
+    def branchString = "\n\t" + boldSequence + "Branch: " + endSequence + branch
+    def commitString = "\n\t" + boldSequence + "Commit Hash: " + endSequence + commitHash
+    def teamNumString = "\n\t" + boldSequence + "Team Number: " + secondSequence + project.frc.getTeamOrDefault(302) + endSequence
+
+    println("Contents: " + branchString + commitString + teamNumString)
 }
 
 model {
@@ -83,47 +124,49 @@ model {
                 targetPlatform wpi.platforms.desktop
             }
 
-            //check for version mismatch
-            String lastBuildDetails = new File(projectDir.toString() + "/src/main/utilities/BuildDetails.txt").text
-
-            String lastTeamNum = lastBuildDetails.takeBetween("(TN)")
-            if(lastTeamNum.toInteger() != project.frc.getTeamOrDefault(302))
-            {
-                
-                ant.input(message: 'Current team number does not match what code was built with, continue? Y/N:', addproperty: 'answer', defaultValue : 'N')
-                def answer = ant.properties.answer
-                if(answer == 'N' || answer == 'n')
-                {
-                    println("Answer was no")
-                    return false
-                }
-            }
-
             sources.cpp {
                 def cppDir = 'src/main/cpp/' //default will be comp bot, will make src/main/cpp/comp later
+                
+                def boldSequence = ansiEscape + boldEffect + ansiEnd
                 switch(project.frc.getTeamOrDefault(302)){
                     case 302:
+                        print(boldSequence)
                         println("Building code for comp bot")
+                        print(endSequence)
                         //don't need to set cppDir because it already points to comp bot
                         break;
                     case 2023:
                     case 2024:
                         cppDir='src/main/cpp/practice'
+
+                        print(boldSequence)
                         println("Building code for practice bot")
+                        print(endSequence)
                         break;
                     case 1:
                         cppDir='src/main/cpp/thing1'
+
+                        print(boldSequence)
                         println("Building code for thing 1")
+                        print(endSequence)
                         break;
                     case 2:
                         cppDir='src/main/cpp/thing2'
+
+                        print(boldSequence)
                         println("Building code for thing 2")
+                        print(endSequence)
+                        break;
                     case 333:
                         cppDir='src/main/cpp/simulation'
+
+                        print(boldSequence)
                         println("Building code for simulation")
+                        print(endSequence)
                         break;
                     default:
-                        println("Team number not found, building code for comp bot")
+                        def startSequence = ansiEscape + boldEffect + ";" + yellowColor + ansiEnd
+                        println(startSequence + "WARNING: " + endSequence + "Team number not found, building code for comp bot")
                         //don't need to set cppDir because it already points to comp bot
                         break;
                 }

--- a/build.gradle
+++ b/build.gradle
@@ -55,13 +55,41 @@ model {
             }
 
             sources.cpp {
+                def cppDir = 'src/main/cpp/' //default will be comp bot, will make src/main/cpp/comp later
+                switch(project.frc.getTeamNumber()){
+                    case 302:
+                        println("Building code for comp bot")
+                        //don't need to set cppDir because it already points to comp bot
+                        break;
+                    case 2023:
+                    case 2024:
+                        cppDir='src/main/cpp/practice'
+                        println("Building code for practice bot")
+                        break;
+                    case 1:
+                        cppDir='src/main/cpp/thing1'
+                        println("Building code for thing 1")
+                        break;
+                    case 2:
+                        cppDir='src/main/cpp/thing2'
+                        println("Building code for thing 2")
+                    case 333:
+                        cppDir='src/main/cpp/simulation'
+                        println("Building code for simulation")
+                        break;
+                    default:
+                        println("Team number not found, building code for comp bot")
+                        //don't need to set cppDir because it already points to comp bot
+                        break;
+                }
+
                 source {
-                    srcDir 'src/main/cpp'
+                    srcDir cppDir
                     srcDir 'src/main/thirdparty'
                     include '**/*.cpp','**/*.cxx', '**/*.cc', '**/*.c'
                 }
                 exportedHeaders {
-                    srcDir 'src/main/cpp'
+                    srcDir cppDir
                     srcDir 'src/main/thirdparty'
                     include '**/*.hpp', '**/*.hxx', '**/*.h'
                 }

--- a/build.gradle
+++ b/build.gradle
@@ -65,9 +65,7 @@ tasks.build.doLast() {
    // Parse the output into a string
    def branch = stdout.toString().trim()
 
-   new File(
-      projectDir.toString() + "/src/main/utilities",
-      "BuildDetails.txt"
+   new File(projectDir.toString() + "/src/main/utilities", "BuildDetails.txt"
    ).text = "Branch: (B)" + branch + "(B) "+ "\nCommit Hash: (H)" + commitHash + "(H)" + "\nTeam Number: (TN)" + project.frc.getTeamNumber() + "(TN)"
 
     println("Wrote details")

--- a/build.gradle
+++ b/build.gradle
@@ -46,12 +46,59 @@ wpi.sim.addGui().defaultEnabled = true
 // Enable DS but not by default
 wpi.sim.addDriverstation()
 
+tasks.build.doLast() {
+   def stdout = new ByteArrayOutputStream()
+
+   exec {
+     commandLine "git", "rev-parse", "HEAD"
+     standardOutput = stdout
+   }
+
+   def commitHash = stdout.toString().trim()
+
+    stdout = new ByteArrayOutputStream()
+    exec {
+      commandLine "git", "rev-parse", "--abbrev-ref", "HEAD"
+      standardOutput = stdout
+   }
+
+   // Parse the output into a string
+   def branch = stdout.toString().trim()
+
+   new File(
+      projectDir.toString() + "/src/main/utilities",
+      "BuildDetails.txt"
+   ).text = "Branch: (B)" + branch + "(B) "+ "\nCommit Hash: (H)" + commitHash + "(H)" + "\nTeam Number: (TN)" + project.frc.getTeamNumber() + "(TN)"
+
+    println("Wrote details")
+    if(ant.properties.answer == 'N' || ant.properties.answer == 'n')
+    {
+        println("Build was not successful even though it says that below.  Please rebuild")
+    }
+}
+
 model {
     components {
         frcUserProgram(NativeExecutableSpec) {
             targetPlatform wpi.platforms.roborio
             if (includeDesktopSupport) {
                 targetPlatform wpi.platforms.desktop
+            }
+
+            //check for version mismatch
+            String lastBuildDetails = new File(projectDir.toString() + "/src/main/utilities/BuildDetails.txt").text
+
+            String lastTeamNum = lastBuildDetails.takeBetween("(TN)")
+            if(lastTeamNum.toInteger() != project.frc.getTeamNumber())
+            {
+                
+                ant.input(message: 'Current team number does not match what code was built with, continue? Y/N:', addproperty: 'answer', defaultValue : 'N')
+                def answer = ant.properties.answer
+                if(answer == 'N' || answer == 'n')
+                {
+                    println("Answer was no")
+                    return false
+                }
             }
 
             sources.cpp {

--- a/src/main/utilities/BuildDetails.txt
+++ b/src/main/utilities/BuildDetails.txt
@@ -1,3 +1,3 @@
 Branch: (B)MultipleRobots(B) 
-Commit Hash: (H)c26cdcd2ce31e7be21486e6aa044033e0ddcc67d(H)
+Commit Hash: (H)8968f3a041eca421ea93b09fb0135c3f9c99384c(H)
 Team Number: (TN)303(TN)

--- a/src/main/utilities/BuildDetails.txt
+++ b/src/main/utilities/BuildDetails.txt
@@ -1,0 +1,3 @@
+Branch: (B)MultipleRobots(B) 
+Commit Hash: (H)c26cdcd2ce31e7be21486e6aa044033e0ddcc67d(H)
+Team Number: (TN)303(TN)

--- a/src/main/utilities/BuildDetails.txt
+++ b/src/main/utilities/BuildDetails.txt
@@ -1,3 +1,3 @@
 Branch: (B)MultipleRobots(B) 
-Commit Hash: (H)0c7502cc69f8bfe7ce4cc57e43e67ffdcf50a9ac(H)
+Commit Hash: (H)d309953ae666da98d458ee71d9c81b63d98e139f(H)
 Team Number: (TN)302(TN)

--- a/src/main/utilities/BuildDetails.txt
+++ b/src/main/utilities/BuildDetails.txt
@@ -1,3 +1,3 @@
 Branch: (B)MultipleRobots(B) 
-Commit Hash: (H)8968f3a041eca421ea93b09fb0135c3f9c99384c(H)
-Team Number: (TN)303(TN)
+Commit Hash: (H)0c7502cc69f8bfe7ce4cc57e43e67ffdcf50a9ac(H)
+Team Number: (TN)302(TN)


### PR DESCRIPTION
Creates a BuildDetails which stores some Git information and the team number used to build.
When deploying, the current team number is checked against the stored number.
If there is a difference, the user is prompted to continue or stop the deploy.
When building with a certain team number, a build directory can be selected so all the different robots' code will be built at the same time.
Attached is a video showing how building and deploying looks now.
https://github.com/Team302/2023SummerProject/assets/71138394/0d1e2a95-68bf-4353-86d0-09141d1e3718

